### PR TITLE
Gpu atomic minmax fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,9 @@ endif()
 
 if(ONIKA_BUILD_CUDA)
   set(ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE OFF CACHE BOOL "GPU supports atomicMin(double) and atomicMax(double)")
-  set(ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE OFF CACHE BOOL "GPU supports atomicMin(double) and atomicMax(double)")
+  if(ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE)
+    list(APPEND ONIKA_GPU_COMPILE_DEFINITIONS ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE=1)  
+  endif()
 endif()
 
 # add GPU flags and compile features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,11 @@ else()
   endif()
 endif()
 
+if(ONIKA_BUILD_CUDA)
+  set(ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE OFF CACHE BOOL "GPU supports atomicMin(double) and atomicMax(double)")
+  set(ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE OFF CACHE BOOL "GPU supports atomicMin(double) and atomicMax(double)")
+endif()
+
 # add GPU flags and compile features
 list(APPEND ONIKA_COMPILE_FEATURES ${ONIKA_GPU_COMPILE_FEATURES})
 list(APPEND ONIKA_COMPILE_DEFINITIONS ${ONIKA_GPU_COMPILE_DEFINITIONS})

--- a/include/onika/cuda/cuda.h
+++ b/include/onika/cuda/cuda.h
@@ -53,7 +53,7 @@ under the License.
 #define ONIKA_ALWAYS_INLINE inline __attribute__((always_inline))
 
 // do we have access to atomicMin and atomicMax on double types ?
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#ifndef ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE
 #define ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE 1
 #endif
 
@@ -304,6 +304,7 @@ namespace onika { namespace cuda { namespace _details {
 #ifndef ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE
 ONIKA_DEVICE_FUNC inline double atomicMin(double* xp , double y)
 {
+# if
   ONIKA_CU_ABORT();
 }
 ONIKA_DEVICE_FUNC inline double atomicMax(double* xp , double y)

--- a/include/onika/cuda/cuda.h
+++ b/include/onika/cuda/cuda.h
@@ -52,11 +52,6 @@ under the License.
 
 #define ONIKA_ALWAYS_INLINE inline __attribute__((always_inline))
 
-// do we have access to atomicMin and atomicMax on double types ?
-#ifndef ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE
-#define ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE 1
-#endif
-
 namespace onika
 {
   namespace cuda
@@ -274,6 +269,8 @@ namespace onika { namespace cuda { namespace _details {
 #   endif
 /************** end host code definitions ***************/
 
+
+
 /***************************************************************/
 /****************** Cuda hardware intrinsics *******************/
 /***************************************************************/
@@ -285,8 +282,30 @@ namespace onika { namespace cuda { namespace _details {
       asm("mov.u32 %0, %smid;" : "=r"(ret) );
       return ret;
     }
+    
+    ONIKA_DEVICE_FUNC inline long long int onika_double_as_longlong(double x) { return __double_as_longlong(x); }
+    ONIKA_DEVICE_FUNC inline double onika_longlong_as_double(long long int x) { return __longlong_as_double(x); }
+    
 #   else
+
     inline constexpr unsigned int get_smid(void) { return 0; }
+    
+    // this might be unefficient as hell, but it doesn't break strict aliasing rules
+    ONIKA_DEVICE_FUNC inline long long int onika_double_as_longlong(double x)
+    {
+      long long int x_ll = 0;
+      static_assert( sizeof(x) == sizeof(x_ll) );
+      memcpy( & x_ll , & x , sizeof(x) );
+      return x_ll;
+    }
+    ONIKA_DEVICE_FUNC inline double onika_longlong_as_double(long long int x_ll)
+    {
+      double x = 0.0;
+      static_assert( sizeof(x) == sizeof(x_ll) );
+      memcpy( & x , & x_ll , sizeof(x_ll) );
+      return x;
+    }
+    
 #   endif
 
     template<class T>
@@ -296,22 +315,46 @@ namespace onika { namespace cuda { namespace _details {
       unsigned char byte[sizeof(T)];
       ONIKA_HOST_DEVICE_FUNC inline T& get_ref() { return * reinterpret_cast<T*>(byte); }
     };
-
   }
 }
 
-// fallback implementation for cuda functions not present in olded releases
+/***************************************************************/
+/************** Cuda extended atomic operations ****************/
+/***************************************************************/
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #ifndef ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE
 ONIKA_DEVICE_FUNC inline double atomicMin(double* xp , double y)
 {
-# if
-  ONIKA_CU_ABORT();
+  using onika::cuda::onika_double_as_longlong;
+  using onika::cuda::onika_longlong_as_double;
+  const unsigned long long int y_ull = onika_double_as_longlong( y );
+  unsigned long long int x_ull = atomicAdd( (unsigned long long int *) xp , 0ull ); // this ensures a portable way to perform an atomic fetch of value at address xp
+  double x = onika_longlong_as_double( x_ull );
+  while( x > y )
+  {
+    x_ull = atomicCAS( (unsigned long long int *) xp , x_ull , y_ull );
+    x = onika_longlong_as_double( x_ull );
+  }
+  return x;
 }
 ONIKA_DEVICE_FUNC inline double atomicMax(double* xp , double y)
 {
-  ONIKA_CU_ABORT();
+  using onika::cuda::onika_double_as_longlong;
+  using onika::cuda::onika_longlong_as_double;
+  const unsigned long long int y_ull = onika_double_as_longlong( y );
+  unsigned long long int x_ull = atomicAdd( (unsigned long long int *) xp , 0ull ); // this ensures a portable way to perform an atomic fetch of value at address xp
+  double x = onika_longlong_as_double( x_ull );
+  while( x < y )
+  {
+    x_ull = atomicCAS( (unsigned long long int *) xp , x_ull , y_ull );
+    x = onika_longlong_as_double( x_ull );
+  }
+  return x;
 }
-# endif
+#endif // if hardware atomicMin / atomicMax are missing
+#endif // device code only
+
+
 
 // user helpers to select implementations depending on Cuda or Host execution space
 #include <onika/integral_constant.h>

--- a/include/onika/memory/allocator.h
+++ b/include/onika/memory/allocator.h
@@ -84,12 +84,8 @@ namespace memory
     static inline constexpr size_t DefaultAlignBytes = std::max( MINIMUM_CUDA_ALIGNMENT , DEFAULT_ALIGNMENT );
     static inline constexpr size_t add_info_size = sizeof(size_t) + sizeof(uint32_t);
     
-#   ifndef NDEBUG
     static bool s_enable_debug_log;
     static void set_debug_log(bool b);
-#   else
-    static inline constexpr void set_debug_log(bool){}
-#   endif
 
     MemoryChunkInfo memory_info( void* ptr , size_t s ) const;
     void* allocate( size_t s , size_t a ) const;

--- a/src/cuda/allocator.cpp
+++ b/src/cuda/allocator.cpp
@@ -46,10 +46,8 @@ namespace onika
     }
 #   endif
 
-#   ifndef NDEBUG
     bool GenericHostAllocator::s_enable_debug_log = false;
     void GenericHostAllocator::set_debug_log(bool b) { s_enable_debug_log = b; }
-#   endif
 
     bool GenericHostAllocator::operator == (const GenericHostAllocator& other) const
     {


### PR DESCRIPTION
hardware suport for atomicMin(double*,double)  and atomicMax(double*,double) is no longer automatically detected but must be explicitly activated through CMake variable ONIKA_HAS_GPU_ATOMIC_MIN_MAX_DOUBLE.
when no hardware is available, an alternative implementation built atop of atomicCAS fonction is enabled. thus results shall be always correct when using atomicMin/atomicMax, even though they may be slower when no hardware support is activated.