### PR TITLE
fixed bug in configuration structure

### DIFF
--- a/include/onika/app/api.h
+++ b/include/onika/app/api.h
@@ -52,6 +52,8 @@ under the License.
 #include <onika/trace/dot_trace_format.h>
 #include <onika/trace/yaml_trace_format.h>
 
+#include <memory>
+
 // dummy function to be used as a breakpoint marker just before simulation is ran
 // usefull for adding breakpoints in loaded plugins
 void simulation_start_breakpoint();
@@ -124,7 +126,7 @@ namespace onika
     std::pair< std::vector<std::string> , YAML::Node >
     parse_command_args( int argc, char const * const argv[] );
 
-    std::tuple<YAML::Node,YAML::Node,onika::app::ApplicationConfiguration>
+    std::tuple< YAML::Node, YAML::Node, std::shared_ptr<onika::app::ApplicationConfiguration> >
     load_yaml_input( const std::vector<std::string>& main_input_files, YAML::Node cmdline = YAML::Node(YAML::NodeType::Map) );
 
     onika::scg::OperatorNode*

--- a/include/onika/app/config_struct.h
+++ b/include/onika/app/config_struct.h
@@ -229,6 +229,8 @@ namespace onika
   { \
     inline ONIKA_APP_CONFIG_Struct_##name ( YAML::Node n , ::onika::app::AppConfigOptionDocumentation* parent_doc=nullptr ) : m_yaml_node( n ) \
     { if(parent_doc!=nullptr) { parent_doc->m_sub_items.push_back( &m_doc ); } } \
+    ONIKA_APP_CONFIG_Struct_##name( ONIKA_APP_CONFIG_Struct_##name & ) = delete; \
+    ONIKA_APP_CONFIG_Struct_##name & operator = ( ONIKA_APP_CONFIG_Struct_##name & ) = delete; \
     YAML::Node m_yaml_node; \
     ::onika::app::AppConfigOptionDocumentation m_doc { std::string{} , #name , std::string{__VA_ARGS__} }
 

--- a/src/core/api.cpp
+++ b/src/core/api.cpp
@@ -78,7 +78,8 @@ namespace onika
 
       onika::app::initialize();
       auto [ main_input_files , cmdline ] = onika::app::parse_command_args( argc , argv );
-      auto [ input_data , simulation_node , configuration ] = onika::app::load_yaml_input( main_input_files , cmdline );
+      auto [ input_data , simulation_node , configuration_ptr ] = onika::app::load_yaml_input( main_input_files , cmdline );
+      auto & configuration = * configuration_ptr;
 
       // ========= optionally override debug mode from env. variable ==========
       const char * env_debug_mode = std::getenv("ONIKA_DEBUG"); // where to look for component plugins to load
@@ -137,7 +138,7 @@ namespace onika
       // prepare operator assembly strategy
       auto simulation_graph = onika::app::build_simulation_graph( configuration , simulation_node );
             
-      ctx->m_configuration = std::make_shared<onika::app::ApplicationConfiguration>(configuration);
+      ctx->m_configuration = configuration_ptr; //std::make_shared<onika::app::ApplicationConfiguration>(configuration);
       ctx->m_input_files = main_input_files;
       ctx->m_cmdline_config = cmdline;
       ctx->m_input_data = input_data;
@@ -256,7 +257,7 @@ namespace onika
 
 
 
-    std::tuple<YAML::Node,YAML::Node,onika::app::ApplicationConfiguration>
+    std::tuple< YAML::Node , YAML::Node , std::shared_ptr<onika::app::ApplicationConfiguration> >
     load_yaml_input( const std::vector<std::string>& main_input_files, YAML::Node cmdline )
     {
       using namespace onika;
@@ -289,7 +290,8 @@ namespace onika
       }
 
       // convert YAML configuration node to data structure
-      onika::app::ApplicationConfiguration configuration { config_node };
+      std::shared_ptr<onika::app::ApplicationConfiguration> configuration_ptr = std::make_shared<onika::app::ApplicationConfiguration>( config_node );
+      auto & configuration = *configuration_ptr;
 
       // allow special block configuration block "set" to overload base input data
       if( configuration.set.IsMap() && configuration.set.size()>0 )
@@ -340,7 +342,7 @@ namespace onika
         lout << std::endl << "==============================" << std::endl << std::endl;
       }
       
-      return { input_data , simulation_node , configuration };
+      return { input_data , simulation_node , configuration_ptr };
     }
     
     


### PR DESCRIPTION
fixed : configuration structure had pointer based reference to its sub-structured members, leading to crash whenever the configuration structure was copied.
first, the fix uses shared_ptr to avoid copies and second, generated configuration structure nos has a copy constructure and a copy operator marked as 'delete' so that the same error cannot occur again.
