### PR TITLE
Onika recommended physical constants

### DIFF
--- a/include/onika/physics/constants.h
+++ b/include/onika/physics/constants.h
@@ -23,16 +23,16 @@ namespace onika
   
   namespace physics
   {
-    static constexpr double atomicMass = 1.66053904020e-27;  ///< Dalton atomic mass unit in kg
-    static constexpr double elementaryCharge = 1.6021892e-19;  ///< Elementary charge in Coulomb
-    static constexpr double boltzmann = 1.380662e-23;  ///< Boltzmann constant in m2 kg s-2 K-1
-    static constexpr double avogadro = 6.02214199e23;  ///< Avogadro constant in mol-1
-    static constexpr double calorie_joules = 4.1868;  ///< calorie in joules
-    static constexpr double epsilonZero = 8.854187e-12; ///< Vacuum permittivity
+    static constexpr double atomicMass = 1.66053906892e-27;  ///< Dalton atomic mass unit in kg
+    static constexpr double elementaryCharge = 1.602176634e-19;  ///< Elementary charge in Coulomb
+    static constexpr double boltzmann = 1.380649e-23;  ///< Boltzmann constant in m2 kg s-2 K-1
+    static constexpr double avogadro = 6.02214076e23;  ///< Avogadro constant in mol-1    
+    static constexpr double calorie_joules = 4.184;  ///< calorie in joules
+    static constexpr double epsilonZero = 8.8541878188e-12; ///< Vacuum permittivity
 
     static constexpr double e = 2.7182818284590452;  ///< Euler's number
     static constexpr double phi = 1.618033988749895;  ///< Golden ratio
-    static constexpr double pi = 3.1415926535897932;  ///< Pi    
+    static constexpr double pi = 3.1415926535897932;  ///< Pi
   }
   
 }

--- a/include/onika/physics/units.h
+++ b/include/onika/physics/units.h
@@ -86,6 +86,10 @@ namespace onika
     
     // shortcuts to particular values
     static inline constexpr auto elementaryChargeCoulomb = elementaryCharge;
+    static inline constexpr auto atomicMassDalton = atomicMass;
+    static inline constexpr auto avogadroNumber = avogadro;
+    static inline constexpr auto calorieJoules = calorie_joules;
+    static inline constexpr auto piValue = pi;
     static inline constexpr auto undefined_value = std::numeric_limits<double>::quiet_NaN();
     
     /*
@@ -118,7 +122,7 @@ namespace onika
     // mass
     static inline constexpr UnitDefinition kilogram           = { MASS       , 1.0                     , "kg"       , "kilogram" };
     static inline constexpr UnitDefinition gram               = { MASS       , 1.0e-3                  , "g"        , "gram" };
-    static inline constexpr UnitDefinition atomic_mass_unit   = { MASS       , 1.660539040e-27         , "Da"       , "Dalton" };
+    static inline constexpr UnitDefinition atomic_mass_unit   = { MASS       , atomicMassDalton        , "Da"       , "Dalton" };
     
     // time
     static inline constexpr UnitDefinition hour               = { TIME       , 3600                    , "h"        , "hour" };
@@ -138,20 +142,20 @@ namespace onika
 
     // amount of substance
     static inline constexpr UnitDefinition mol                = { AMOUNT     , 1.0                     , "mol"      , "mol" };
-    static inline constexpr UnitDefinition particle           = { AMOUNT     , 1.0e-23 / 6.02214076    , "particle" , "particle" }; 
+    static inline constexpr UnitDefinition particle           = { AMOUNT     , 1.0/avogadroNumber      , "particle" , "particle" }; 
 
     // luminosity
     static inline constexpr UnitDefinition candela            = { LUMINOSITY , 1.0                     , "cd"       , "candela" };
 
     // angle
     static inline constexpr UnitDefinition radian             = { ANGLE      , 1.0                     , "rad"      , "radian" };
-    static inline constexpr UnitDefinition degree             = { ANGLE      , M_PI/180.0              , "degree"   , "degree" };
+    static inline constexpr UnitDefinition degree             = { ANGLE      , piValue/180.0           , "degree"   , "degree" };
 
     // energy
     static inline constexpr UnitDefinition joule              = { ENERGY     , 1.0                     , "J"        , "joule" };
     static inline constexpr UnitDefinition electron_volt      = { ENERGY     , elementaryChargeCoulomb , "eV"       , "electron_volt" };
-    static inline constexpr UnitDefinition calorie            = { ENERGY     , 4.1868                  , "cal"      , "calorie" };
-    static inline constexpr UnitDefinition kcalorie           = { ENERGY     , 4186.8                  , "kcal"     , "kcalorie" };
+    static inline constexpr UnitDefinition calorie            = { ENERGY     , calorieJoules           , "cal"      , "calorie" };    
+    static inline constexpr UnitDefinition kcalorie           = { ENERGY     , 1.0e3*calorieJoules     , "kcal"     , "kcalorie" };
     
     // unit less
     static inline constexpr UnitDefinition no_unity           = { OTHER      , 1.0                     , ""         , "" };


### PR DESCRIPTION
I suggest we modify the physical constants defined in onika with the CODATA recommended values version 2022:

https://journals.aps.org/rmp/abstract/10.1103/RevModPhys.97.025002
https://pml.nist.gov/cuu/pdf/wall_2022.pdf

