### PR TITLE
Sets output slot 'result' to true at regular physical time intervals

### DIFF
--- a/src/scg-builtin-components/physical_time_interval.cpp
+++ b/src/scg-builtin-components/physical_time_interval.cpp
@@ -1,0 +1,68 @@
+/*
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+ */
+
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+#include <onika/log.h>
+
+namespace onika
+{
+  namespace scg_builtin
+  {
+
+    using namespace scg;
+
+    class PhysicalTimeInterval : public OperatorNode
+    {
+      static inline constexpr double default_end_time = std::numeric_limits<double>::infinity();
+      static inline constexpr double default_prev_time = - std::numeric_limits<double>::infinity();
+    
+      ADD_SLOT( double , physical_time , INPUT_OUTPUT );
+
+      ADD_SLOT( double , start_time , INPUT , 0.0 );
+      ADD_SLOT( double , end_time , INPUT , default_end_time );
+      ADD_SLOT( double , time_interval , INPUT , 0.0 );
+
+      ADD_SLOT( double , previous_physical_time , INPUT_OUTPUT , default_prev_time );
+      ADD_SLOT( bool , result , INPUT_OUTPUT);
+
+      public:
+      void execute() override final
+      {
+        if( (*time_interval) > 0.0 && (*physical_time) >= (*start_time) && (*physical_time) <= (*end_time) && ( (*physical_time) - (*previous_physical_time) ) >= (*time_interval) )
+        {
+          *previous_physical_time = *physical_time;
+          *result = true;
+        }
+        else
+        {
+          *result = false;
+        }
+      }
+
+    };
+
+    // === register factories ===  
+    ONIKA_AUTORUN_INIT(physical_time_interval)
+    {
+      OperatorNodeFactory::instance()->register_factory( "physical_time_interval", make_compatible_operator< PhysicalTimeInterval > );
+    }
+  }
+}


### PR DESCRIPTION
allow simulation to trigger actions at regular physical time intervals rather than counting timesteps.
as an exemple, if you want to add support for physical time interval in addition to timsteps interval for simulation logs, you may replace a block like the original one in exaNBody :
...
 trigger_print_log:
  rebind: { freq: simulation_log_frequency , result: trigger_print_log }
  body:
    - nth_timestep: { first: true }
...
with smething like this :
...
trigger_print_log:
  - trigger_nth_timesteps:
      rebind: { freq: simulation_log_frequency , result: trigger1 }
      body:
        - nth_timestep: { first: true }
  - trigger_time_interval:
      rebind: { time_interval: simulation_log_time_interval , start_time: simulation_log_time_start , end_time: simulation_log_time_end , result: trigger2 }
      body:
        - physical_time_interval
  - combine:
      rebind: { in1: trigger1 , in2: trigger2 , result: trigger_print_log }
      body: [ boolean_or ]
...


then, you may modify your simulation input file to set simulation_log_time_interval, simulation_log_time_start and simulation_log_time_end in your global block, or set it from the command line as follows : 
...
./exaNBody input_lj_Ni.msp --set-simulation_epilog nop --set-global-simulation_log_time_interval "1e-2 ps" --set-global-simulation_log_time_start "1.0e-1 ps" --set-global-simulation_log_time_end "1.7e-1 ps"  --set-global-simulation_log_frequency "-1"
...
