### PR TITLE
Fix hip compilation

### DIFF
--- a/.github/workflows/cmake_hip.yml
+++ b/.github/workflows/cmake_hip.yml
@@ -1,11 +1,10 @@
 name: CMake HIP
 on:
-  push
-  # push:
-  #   branches:
-  #     - main
-  #   pull_request:
-  #     - main
+  push:
+    branches:
+      - main
+    pull_request:
+      - main
   
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake_hip.yml
+++ b/.github/workflows/cmake_hip.yml
@@ -1,10 +1,11 @@
 name: CMake HIP
 on:
-  push:
-    branches:
-      - main
-    pull_request:
-      - main
+  push
+  # push:
+  #   branches:
+  #     - main
+  #   pull_request:
+  #     - main
   
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/include/onika/omp/version.h
+++ b/include/onika/omp/version.h
@@ -33,11 +33,13 @@ namespace onika
     inline double get_version()
     {
       double version = 3.0;
+#ifdef _OPENMP
       std::pair<unsigned long,double> version_dates [] = { {200505,2.5},{200805,3.0},{201107,3.1},{201307,4.0},{201511,4.5},{201811,5.0},{202011,5.1} };
       for(int i=0;i<7;i++)
       {
         if( version_dates[i].first < _OPENMP ) version = version_dates[i].second;
       }
+#endif
       return version;
     }
     

--- a/include/onika/parallel/parallel_execution_space.h
+++ b/include/onika/parallel/parallel_execution_space.h
@@ -137,7 +137,7 @@ namespace onika
       coord_t m_end;
       element_list_t m_elements = {};
       
-      static inline consteval unsigned int space_nd() { return SpaceNDim; }
+      static inline constexpr unsigned int space_nd() { return SpaceNDim; }
       inline constexpr size_t number_of_items() const { return coord_range_size( m_start , m_end ); }
     };
 


### PR DESCRIPTION
## Fix HIP build errors

  - `include/onika/omp/version.h`: guard the `_OPENMP`-dependent code in
    `get_version()` with `#ifdef _OPENMP`. Clang's HIP device-compilation
    pass doesn't define `_OPENMP`, causing an "undeclared identifier" error.

  - `include/onika/parallel/parallel_execution_space.h`: change
    `ParallelExecutionSpace::space_nd()` from `consteval` to `constexpr`.
    HIPCC's unified host+device pass fails to prove the `consteval`
    call (made through a virtual override) is an immediate constant
    expression, even though it's host-only code. `constexpr` keeps the
    same compile-time-constant behavior without that strict requirement.

  No effect on the CUDA or CPU-only builds. Tests have been checked and pass at 100%.